### PR TITLE
[BUGFIX] Ensure root extension install does not drop extensions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
           - "v2"
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP version and composer
         uses: shivammathur/setup-php@v2

--- a/CHANGELOG-0.x.md
+++ b/CHANGELOG-0.x.md
@@ -1,6 +1,9 @@
 CHANGELOG for 0.x
 =================
 
+* 0.1.x
+  - [BUGFIX] Ensure root extension install does not drop dedicated extensions
+
 * 0.1.1
   - [BUGFIX] Support links on Windows systems - thanks to IchHabRecht
   - [TASK] Use correct homepage link in composer.json - thanks to IchHabRecht


### PR DESCRIPTION

The plugin service provides dedicated methods to separate needed steps. Each methods used the composer filesystem method to ensure empty paths. Root package linking is done after eventually other extensions are symlinked. In this consteallation other extensions got vanished due empty the legacy extension folder first.

This change moves the empty folder to early point, and using only method to ensure existing folder instead of empty it. That way all cases should be covered.

Resolves: #7