### PR TITLE
[TASK] Add description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "sbuerk/typo3-cmscomposerinstallers-testingframework-bridge",
+    "description": "Compatibility patch for extension testing with TYPO3 v12",
     "type": "composer-plugin",
     "homepage": "https://github.com/sbuerk/typo3-cmscomposerinstallers-testingframework-bridge",
     "license": "GPL-2.0-or-later",


### PR DESCRIPTION
A description should exist in composer.json, otherwise composer validate shows a warning.

Also, the missing description might result in an exception in Composer (see related issue).

Resolves: #9